### PR TITLE
Use embed API for all valid figma links

### DIFF
--- a/src/ensureEmbedFlags.js
+++ b/src/ensureEmbedFlags.js
@@ -1,9 +1,8 @@
 export const ensureEmbedFlags = (url) => {
   if (!url) return
 
-  if (url.includes('figma.com/embed')) {
-    return url
-  } else {
-    return `https://www.figma.com/embed?embed_host=share&url=${encodeURIComponent(url)}`
-  }
+  // From https://www.figma.com/developers/embed
+  if (!url.match(/https:\/\/([\w\.-]+\.)?figma.com\/(file|proto)\/([0-9a-zA-Z]{22,128})(?:\/.*)?$/)) return
+
+  return `https://www.figma.com/embed?embed_host=share&url=${encodeURIComponent(url)}`
 }


### PR DESCRIPTION
The extension previously used the URL as provided if it didn't match `figma.com/embed`. This results in direct links to figma files being loaded directly in the iframe. Figma has recently stopped allowing embeds in this format.