### PR TITLE
DEVELOP-1619: Latest version of Figma extension fails to load content

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     }
   },
   "dependencies": {
-    "@aha-develop/aha-develop-react": "^1.4.0",
+    "@aha-develop/aha-develop-react": "^1.4.2",
     "prettier": "^2.8.1"
   }
 }

--- a/src/views/figmaAttribute.js
+++ b/src/views/figmaAttribute.js
@@ -13,6 +13,7 @@ aha.on("figmaAttribute", ({ record, fields }) => {
       product="Figma"
       fieldName="figmaLink"
       placeholder="Add Figma URL"
+      transformValue={ensureEmbedFlags}
     />
   );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     open "^7.3.0"
     tslib "^1"
 
-"@aha-develop/aha-develop-react@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@aha-develop/aha-develop-react/-/aha-develop-react-1.4.0.tgz#48f75b29e8a3bede834daa5930428185f070f1d4"
-  integrity sha512-oG35010sDwV9gHrOCuB6ZkhQ5oA2JGvSiueWRcG51Cww+ey3t/LHTSsNaUksLd1eAkKIYDj98xPAmWsG67M9KQ==
+"@aha-develop/aha-develop-react@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@aha-develop/aha-develop-react/-/aha-develop-react-1.4.2.tgz#39d4be8472b723075e4e07fc6f57855ce1018d5a"
+  integrity sha512-bqkleoOwqMpF0F0Iff1ol8lytMKr93DAuXg1Q8TAIVuKncW/lb93vuEW6ZyNLnikOiA3MbQV68BDD1ohvIMweg==
 
 "@fal-works/esbuild-plugin-global-externals@^2.1.1":
   version "2.1.2"


### PR DESCRIPTION
Add `transformValue` to support direct links

The extension should support direct links to the Figma page as well as pasting in the actual "embed" link. We need to call the `ensureEmbedFlags` function to transform the value if it's not the embed link.